### PR TITLE
Fix for handling Bye... last line message, JSON stringify of logging

### DIFF
--- a/buffer.js
+++ b/buffer.js
@@ -54,7 +54,7 @@ function readValues(ios,type,data)
       var key = parts[0].trim();
 
       // ignore set status
-      if (parts[2].substr(0,4) == 'set_') {return;};
+      if (typeof parts[2] === "undefined" || parts[2].substr(0,4) == 'set_') {return};
 
       newValues[key] = parts[2];
       newTypes[key] = lastHeader;

--- a/buffer.js
+++ b/buffer.js
@@ -43,6 +43,9 @@ function readValues(ios,type,data)
       // ignore unpeered values
       if (line.indexOf('unpeered') > 0) {return;};
 
+      // ignore Bye, last line infos
+      if (line.indexOf('Bye...') >= 0) {return;};
+
       //ignore first line
       ln++;
       if (ln == 1) {return};
@@ -63,7 +66,7 @@ function readValues(ios,type,data)
       aktTypes = JSON.parse(JSON.stringify(newTypes));
       initFinished.emit('true');
       mylog("aktValues:",2);
-      mylog(aktValues,2);
+      mylog(JSON.stringify(aktValues),2);
    }
    else
    {
@@ -74,7 +77,7 @@ function readValues(ios,type,data)
             aktValues[key] = newValues[key];
             aktTypes[key] = newTypes[key];
             var jsonValue = checkValue(key);
-            mylog(jsonValue,2);
+            mylog("JSONvalue: " + JSON.stringify(jsonValue),2);
             ios.sockets.in('all').emit('value',jsonValue);
             ios.sockets.in(key).emit('value',jsonValue);
          }


### PR DESCRIPTION
Fixes the error always got on server start:

```
25.04.2015 23:35:46 Parts: Sonos_SchlafzimmerRC_Weblink ,(,initialized,),
25.04.2015 23:35:46 Parts: WetterHTML           ,(,initialized,),
25.04.2015 23:35:46 Parts: Bye...
/home/pi/dev/fhem.js/buffer.js:56
      if (parts[2].substr(0,4) == 'set_') {return;};
                  ^
TypeError: Cannot read property 'substr' of undefined
    at /home/pi/dev/fhem.js/buffer.js:56:19
    at Array.forEach (native)
    at Object.readValues (/home/pi/dev/fhem.js/buffer.js:17:13)
    at Socket.<anonymous> (/home/pi/dev/fhem.js/server.js:314:14)
    at Socket.emit (events.js:129:20)
    at _stream_readable.js:908:16
    at process._tickCallback (node.js:355:11)
```

Also changed the output of readValues() to stringily the JSON.
