### PR TITLE
Added option to configure an external host running fhem.pl

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Now follow the instructions made by the installation output, e.g. run:
 
 This will establish the config environment in /etc/fhem.js and /etc/init.d.
 
-Have a look to /etc/fhem.js/params.js. Adjust telnet port of fhem if neccessary. Optionally set a connection password or set SSL for connections can be done there.
+Have a look to /etc/fhem.js/params.js. Adjust the hostname (default is `localhost`) and telnet port of fhem.pl if neccessary. Optionally set a connection password or set SSL for connections can be done there.
 
 Now starting the server with
 
@@ -56,9 +56,9 @@ Communication to clients with websockets were realized by the socket.io package.
 
 # Customize
 
-Adjust in params.js telnet port of fhem.pl server and port on which this server (fhem.js) is reachable.
+Adjust in params.js the hostname and telnet port of the fhem.pl server and the port on which this server (fhem.js) is reachable.
 
-The fhem.pl server must be on the same server and the telnet must be configured without local password.
+The telnet must be configured without local password.
 
 To secure the connection to this node.js server with SSL set
 

--- a/etc/fhem.js/params.js.dist
+++ b/etc/fhem.js/params.js.dist
@@ -4,6 +4,9 @@ exports.debug = 0;
 // port on which node.js service is reachable
 exports.nodePort = 8086;
 
+// Hostname or IP of the FHEM server
+exports.fhemHost = "127.0.0.1";
+
 // telnet port of FHEM server
 exports.fhemPort = 7072;
 

--- a/server.js
+++ b/server.js
@@ -185,7 +185,7 @@ var defListeners = function(socket)
    socket.on('command', function(cmd,callback)
    {
       // establish telnet connection to fhem server
-      var fhemcmd = net.connect({port: params.fhemPort}, function()
+      var fhemcmd = net.connect({port: params.fhemPort, host: params.fhemHost}, function()
       {
           fhemcmd.write(cmd + ';exit\r\n');
       });
@@ -228,7 +228,7 @@ var defListeners = function(socket)
       {
          // establish telnet connection to fhem server
          mylog("request for JsonList2",1);
-         var fhemcmd = net.connect({port: params.fhemPort}, function()
+         var fhemcmd = net.connect({port: params.fhemPort, host: params.fhemHost}, function()
          {
              fhemcmd.write('JsonList2 ' + args + ';exit\r\n');
          });
@@ -261,7 +261,7 @@ var defListeners = function(socket)
    {
       mylog("commandNoResp " + data,1);
       // establish telnet connection to fhem server
-      var fhemcmd = net.connect({port: params.fhemPort}, function()
+      var fhemcmd = net.connect({port: params.fhemPort, host: params.fhemHost}, function()
       {
          fhemcmd.write(data + '\r\n');
          fhemcmd.end();
@@ -295,7 +295,7 @@ initFinished.on('true',function()
 function connectFHEMserver()
 {
    funcs.mylog("start connection to fhem server",0);
-   var trigger = net.connect({port: params.fhemPort}, function()
+   var trigger = net.connect({port: params.fhemPort, host: params.fhemHost}, function()
    {
       funcs.mylog('connected to fhem server for listen on changed values',0);
       trigger.write('inform on\r\n');
@@ -332,7 +332,7 @@ function connectFHEMserver()
 function getAllValues(type)
 {
    // establish telnet connection to fhem server
-   var fhemreq = net.connect({port: params.fhemPort}, function()
+   var fhemreq = net.connect({port: params.fhemPort, host: params.fhemHost}, function()
    {
       fhemreq.write('list;exit\r\n');
    });
@@ -409,7 +409,7 @@ function getDevice(device)
 {
    // establish telnet connection to fhem server
    mylog('get Jsonlist2 for device ' + device,1);
-   var fhemreq = net.connect({port: params.fhemPort}, function()
+   var fhemreq = net.connect({port: params.fhemPort, host: params.fhemHost}, function()
    {
       fhemreq.write('JsonList2 ' + device + ';exit\r\n');
    });


### PR DESCRIPTION
Set an IP for the new param `fhemHost` in `/etc/fhem.js/params.js` to let `fhem.js` connect to a FHEM server running on a different host. Defaults to `127.0.0.1` (localhost).
