### PR TITLE
fix "indexOf" error spamming the log

### DIFF
--- a/server.js
+++ b/server.js
@@ -368,7 +368,7 @@ function handleChangedValues(allLines) {
             if (lineparts.length > 2) {
 
                 // ignore values containing tags out of params.filterOutTags
-                if (params.filterOutTags.indexOf(lineparts[2]) > -1) {
+                if (params.filterOutTags && params.filterOutTags.indexOf(lineparts[2]) > -1) {
                     return;
                 }
 


### PR DESCRIPTION
This commit fixes 
` process error: TypeError: Cannot read property 'indexOf' of undefined - retry in 10 secs`
console outputs.